### PR TITLE
Set ctx.request.validatedBody

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -23,6 +23,7 @@ Apicco leverages [convention over configuration](https://en.wikipedia.org/wiki/C
 - [Parameter validation](#parameter-validation)
 - [Middleware interception](#options)
 - [Discovery endpoint](#discovery)
+- [Request body formatting](#formatting)
 - [Minimal SDK](https://github.com/SokratisVidros/apicco/blob/master/sdk/README.md)
 - [Versionless clients](https://github.com/SokratisVidros/apicco/blob/master/sdk/README.md)
 
@@ -80,6 +81,14 @@ If the validation fails, an HTTP 400 response will be returned to the client, al
 Apicco exposes a discovery endpoint that contains a JSON representation of all the API resources and action files and is used by SDKs (clients) upon initialization.
 
 The discover **GET** endpoint is mounted at `/{prefix}/discovery`.
+
+<a name="formatting"></a>
+
+#### Formatting
+
+Apicco can be also used for request body conversions and formatting. Apicco uses [Joi](https://github.com/hapijs/joi). That is, if the validation convert option is on (enabled by default), a string will be converted using the specified modifiers for string.lowercase(), string.uppercase(), string.trim(), and each replacement specified with string.replace().
+
+The converted request body can be accessed at `ctx.request.validatedBody`;
 
 ### Action files
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -26,7 +26,9 @@ function validate({
     const opts = merge({}, { abortEarly: false }, options);
 
     if (ctx.request.body) {
-      const { error } = joi.validate(ctx.request.body, schema, opts);
+      const { error, value } = joi.validate(ctx.request.body, schema, opts);
+
+      ctx.request.validatedBody = value;
 
       if (!isEmpty(error)) {
         switch (errorCode) {
@@ -40,6 +42,8 @@ function validate({
             });
         }
       }
+    } else {
+      console.warn('Missing ctx.request.body...');
     }
 
     return next();

--- a/lib/validate.test.js
+++ b/lib/validate.test.js
@@ -4,13 +4,34 @@ const Joi = require('joi');
 const validate = require('./validate');
 
 describe('validate({ schema, joi, joiOptions }) middleware', () => {
-  function mockCtx() {
+  function mockCtx(values = {}) {
     return {
       request: {
-        body: {}
+        body: {
+          ...values
+        }
       }
     };
   }
+
+  test('sets request.validatedBody on ctx', async () => {
+    const ctx = mockCtx({ foo: ' BAR ' });
+    const next = jest.fn();
+    const schema = {
+      foo: Joi.string()
+        .lowercase()
+        .trim()
+    };
+
+    await validate({
+      schema,
+      joi: Joi
+    })(ctx, next);
+
+    expect(ctx.request.validatedBody).toEqual({
+      foo: 'bar'
+    });
+  });
 
   describe('when validation error exists', () => {
     test('throws a 422 boom error including detailed error data', async () => {


### PR DESCRIPTION
Joi can be also used as request.body formatter. The formatted values can be extracted from ctx.request.validatedBody field.

Fixes #5 