### PR TITLE
Feat: support returning Joi.object as validate schema

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -74,20 +74,16 @@ function buildAPI({
 
       const params = [];
 
-      for (const param in validate) {
-        if (!validate.hasOwnProperty(param)) {
-          continue;
-        }
+      let joiSchema = validate;
+      if (!joiSchema.isJoi) {
+        joiSchema = joi.object(validate);
+      }
 
-        const { isJoi = true, _flags = {} } = validate[param];
+      const validateParams = joiSchema.describe().children;
+      for (const param in validateParams) {
+        const { flags = {} } = validateParams[param];
 
-        if (!isJoi) {
-          throw new Error(
-            `Invalid Joi validation for ${actionName} action: ${param}.`
-          );
-        }
-
-        const paramsName = _flags.presence === 'required' ? `*${param}` : param;
+        const paramsName = flags.presence === 'required' ? `*${param}` : param;
 
         params.push(paramsName);
       }

--- a/lib/build.test.js
+++ b/lib/build.test.js
@@ -17,7 +17,7 @@ describe('buildAPI(opts)', () => {
   }
 
   beforeAll(() => {
-    jest.mock('require-directory', () => jest.fn(() => {
+    this.mockedDirectory = jest.fn(() => {
       const Joi = require('joi');
 
       return {
@@ -43,7 +43,9 @@ describe('buildAPI(opts)', () => {
           }
         }
       };
-    }));
+    });
+
+    jest.mock('require-directory', () => this.mockedDirectory);
   });
 
   test('sanity check', async () => {
@@ -76,6 +78,51 @@ describe('buildAPI(opts)', () => {
       path: '/api/v1/discovery'
     });
     const next = jest.fn();
+
+    await buildAPI()(ctx, next);
+
+    expect(ctx._matchedRoute).toBe('/api/v1/discovery');
+    expect(ctx.body).toEqual({
+      'books.read': expect.arrayContaining(['*title', 'author']),
+      'movies.list': [],
+      'movies.play': expect.arrayContaining(['*title'])
+    });
+  });
+
+  test('supports returning Joi.object in validation', async () => {
+    const ctx = mockCtx({
+      method: 'GET',
+      path: '/api/v1/discovery'
+    });
+    const next = jest.fn();
+
+    this.mockedDirectory = jest.fn(() => {
+      const Joi = require('joi');
+
+      return {
+        movies: {
+          list: {
+            validate: {},
+            handle: () => {}
+          },
+          play: {
+            validate: {
+              title: Joi.string().required()
+            },
+            handle: () => {}
+          }
+        },
+        books: {
+          read: {
+            validate: Joi.object({
+              title: Joi.string().required(),
+              author: Joi.string()
+            }),
+            handle: () => {}
+          }
+        }
+      };
+    });
 
     await buildAPI()(ctx, next);
 


### PR DESCRIPTION
Supports the following (example retrieved from added test):
```js
module.exports = {
  validate: Joi.object({
    title: Joi.string().required(),
    author: Joi.string()
  }),
  handle: () => { }
};
```

Related Issue: https://github.com/SokratisVidros/apicco/issues/7