### PR TITLE
Handle RestClient::ExceptionWithResponse without http_code

### DIFF
--- a/sdk/ruby/lib/apicco-sdk/client.rb
+++ b/sdk/ruby/lib/apicco-sdk/client.rb
@@ -57,7 +57,7 @@ module ApiccoSDK
       response = _execute(method, url, payload, headers)
       parse_response(response) unless response.code == 204
     rescue ::RestClient::ExceptionWithResponse => e
-      raise e if e.http_code > 501
+      raise e if !e.http_code || e.http_code > 501
       parse_response(e.response)
     end
 

--- a/sdk/ruby/test/apicco-sdk/client_test.rb
+++ b/sdk/ruby/test/apicco-sdk/client_test.rb
@@ -81,4 +81,16 @@ class ClientTest < Minitest::Test
 
     assert_equal(response_payload, response)
   end
+
+  def test_rethrows_network_errors
+    payload = { required_arg1: '1', required_arg2: '2', arg3: '3' }
+
+    stub_discovery_request
+    api = ApiccoSDK::Client.new(@origin)
+    ::RestClient::Request.expects(:execute).raises(RestClient::ExceptionWithResponse)
+
+    assert_raises RestClient::ExceptionWithResponse do
+      api.resource_required_action(payload)
+    end
+  end
 end


### PR DESCRIPTION
There seem to be cases where this class of errors are thrown without an HTTP Code. We have experienced this on our live deployments, but were unable to pinpoint the actual error.

Instead we get

```
undefined method `>' for nil:NilClass
```

By code provided on [rest-client](https://github.com/rest-client/rest-client/tree/v2.0.2#response-callbacks-error-handling) it seems we should handle this.