### PR TITLE
Bump json gem to latest 2.x version

### DIFF
--- a/sdk/ruby/apicco-sdk.gemspec
+++ b/sdk/ruby/apicco-sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "json", "~> 2.2.0"
+  spec.add_dependency "json", "~> 2.5"
   spec.add_dependency "rest-client", "~> 2.0.2"
 
   spec.add_development_dependency "bundler", "~> 2.0.2"


### PR DESCRIPTION
Bumps json gem version to latest 2.x version ([2.5.1](https://github.com/flori/json/blob/master/CHANGES.md#2020-12-22-251)) in order to fix deprecation warning regarding the [planned incompatibility of keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)